### PR TITLE
Replace http:// with // when requesting fonts from googleapis. 

### DIFF
--- a/client/stylesheets/less/typo/typo.import.less
+++ b/client/stylesheets/less/typo/typo.import.less
@@ -1,4 +1,4 @@
 /* fonts */
 //@import url(http://fonts.googleapis.com/css?family=Inconsolata:400,700);
-@import url(http://fonts.googleapis.com/css?family=Droid+Serif);
-@import url(http://fonts.googleapis.com/css?family=Droid+Sans);
+@import url("//fonts.googleapis.com/css?family=Droid+Serif");
+@import url("//fonts.googleapis.com/css?family=Droid+Sans");


### PR DESCRIPTION
This allows for fonts to be requested via http or https, without having a page with mixed requests. Some browsers deny http requests when the original page is over https
